### PR TITLE
fix #2069 0x97-Appendix-V_Cryptography.md 2025/4/7 更新分の取り込み

### DIFF
--- a/5.0/ja/0x97-Appendix-V_Cryptography.md
+++ b/5.0/ja/0x97-Appendix-V_Cryptography.md
@@ -165,7 +165,7 @@ MAC-then-encrypt はレガシーアプリケーションとの互換性のため
 | ------------ | ------------ | ---------------------- | ---------- |
 | argon2 | RFC 9106 | Argon2ID: Memory Cost 19MB, Time Cost 2, Parallelism 1 | A |
 | scrypt | RFC 7914 | 2^15 r = 8 p = 1 | | A |
-| bcrypt |[A Future-Adaptable Password Scheme](https://www.usenix.org/legacy/events/usenix99/provos/provos.pdf) | At least 10 rounds. | | A |
+| bcrypt |[A Future-Adaptable Password Scheme](https://www.researchgate.net/publication/2519476_A_Future-Adaptable_Password_Scheme) | At least 10 rounds. | A |
 | PBKDF2_SHA512 | [NIST SP 800-132](https://csrc.nist.gov/pubs/sp/800/132/final), [FIPS 180-4](https://csrc.nist.gov/pubs/fips/180-4/upd1/final) | 210,000 iterations | A |
 | PBKDF2_SHA256 | [NIST SP 800-132](https://csrc.nist.gov/pubs/sp/800/132/final), [FIPS 180-4](https://csrc.nist.gov/pubs/fips/180-4/upd1/final) | 600,000 iterations | A |
 | PBKDF2-HMAC-SHA-1 | [NIST SP 800-132](https://csrc.nist.gov/pubs/sp/800/132/final), [FIPS 180-4](https://csrc.nist.gov/pubs/fips/180-4/upd1/final) | 1,300,000 iterations | L |


### PR DESCRIPTION
0x97-Appendix-V_Cryptography.md 2025/4/7 更新情報
https://github.com/OWASP/ASVS/commit/12a241a671f60368bb1a470459303f7c88e6db2f#diff-2e9f6d11881cae6343ed9c74c9f54dc472c907a126b90a8581b5a4be8e0ad3af