### PR TITLE
fix #2105 0x97-Appendix-V_Cryptography.md 2025/4/12 更新分の取り込み

### DIFF
--- a/5.0/ja/0x97-Appendix-V_Cryptography.md
+++ b/5.0/ja/0x97-Appendix-V_Cryptography.md
@@ -176,11 +176,11 @@ MAC-then-encrypt はレガシーアプリケーションとの互換性のため
 
 すべての鍵交換スキームに対して 112 ビット以上のセキュリティ強度が確保されていなければならず (MUST)、その実装は以下の表のパラメータ選択に従わなければなりません (MUST)。
 
-| スキーム | ドメインパラメータ | ステータス |
-|--|--|--|
-| RSA | k >= 3072 | A |
-| Finite Field Diffie-Hellman (FFDH) | L >= 3072 & N >= 256 | A |
-| Elliptic Curve Diffie-Hellman (ECDH) | f >= 256-383 | A |
+| スキーム | ドメインパラメータ | 前方秘匿性 | ステータス |
+|--|--|--|--|
+| Finite Field Diffie-Hellman (FFDH) | L >= 3072 & N >= 256 | Yes | A |
+| Elliptic Curve Diffie-Hellman (ECDH) | f >= 256-383 | Yes | A |
+| Encrypted key transport with RSA-PKCS#1 v1.5 | k >= 3072 | No | L |
 
 ここでのパラメータは以下のとおりです:
 


### PR DESCRIPTION
0x97-Appendix-V_Cryptography.md 2025/4/12 更新情報
https://github.com/OWASP/ASVS/commit/d10ded2ce19dbc0f11a4d07673bb81c06b36f0d0#diff-2e9f6d11881cae6343ed9c74c9f54dc472c907a126b90a8581b5a4be8e0ad3af