### PR TITLE
fix #2359 0x97-Appendix-V_Cryptography.md 2025/5/23 更新分の取り込み

### DIFF
--- a/5.0/ja/0x97-Appendix-V_Cryptography.md
+++ b/5.0/ja/0x97-Appendix-V_Cryptography.md
@@ -223,7 +223,7 @@ MAC-then-encrypt はレガシーアプリケーションとの互換性のため
 |--|--|--|--|
 | Finite Field Diffie-Hellman (FFDH) | L >= 3072 & N >= 256 | Yes | A |
 | Elliptic Curve Diffie-Hellman (ECDH) | f >= 256-383 | Yes | A |
-| Encrypted key transport with RSA-PKCS#1 v1.5 | k >= 3072 | No | L |
+| Encrypted key transport with RSA-PKCS#1 v1.5 | | No | D |
 
 ここでのパラメータは以下のとおりです:
 


### PR DESCRIPTION
0x97-Appendix-V_Cryptography.md 2025/5/23 更新情報
https://github.com/OWASP/ASVS/commit/e25c4d710e37bb9121c442ea46dafeac09654f73#diff-2e9f6d11881cae6343ed9c74c9f54dc472c907a126b90a8581b5a4be8e0ad3af