### PR TITLE
fix #2397 0x97-Appendix-V_Cryptography.md 2025/5/25 更新分の取り込み

### DIFF
--- a/5.0/ja/0x97-Appendix-V_Cryptography.md
+++ b/5.0/ja/0x97-Appendix-V_Cryptography.md
@@ -137,6 +137,9 @@ MAC-then-encrypt はレガシーアプリケーションとの互換性のため
 | AES-GCM | [SP 800-38D](https://csrc.nist.gov/pubs/sp/800/38/d/final) | A |
 | AES-CCM | [SP 800-38C](https://csrc.nist.gov/pubs/sp/800/38/c/upd1/final) | A |
 | ChaCha-Poly1305 | [RFC 7539](https://datatracker.ietf.org/doc/html/rfc7539) | A |
+| AEGIS-256  | [AEGIS: A Fast Authenticated Encryption Algorithm (v1.1)](https://competitions.cr.yp.to/round3/aegisv11.pdf) | A |
+| AEGIS-128  | [AEGIS: A Fast Authenticated Encryption Algorithm (v1.1)](https://competitions.cr.yp.to/round3/aegisv11.pdf) | A |
+| AEGIS-128L | [AEGIS: A Fast Authenticated Encryption Algorithm (v1.1)](https://competitions.cr.yp.to/round3/aegisv11.pdf) | A |
 | Encrypt-then-MAC | | A |
 | MAC-then-encrypt | | L |
 
@@ -275,7 +278,7 @@ Diffie-Hellman 鍵交換の実装には以下のグループが承認されて�
 | HMAC-SHA-512  | [RFC 2104](https://www.rfc-editor.org/info/rfc2104) & [FIPS 198-1](https://csrc.nist.gov/pubs/fips/198-1/final) | A | |
 | KMAC128       | [NIST SP 800-185](https://csrc.nist.gov/pubs/sp/800/185/final)                             | A | |
 | KMAC256       | [NIST SP 800-185](https://csrc.nist.gov/pubs/sp/800/185/final)                             | A | |
-| BLAKE3        | [BLAKE3 one function, fast everywhere](https://github.com/BLAKE3-team/BLAKE3-specs/raw/master/blake3.pdf)  | A | |
+| BLAKE3 (keyed_hash mode) | [BLAKE3 one function, fast everywhere](https://github.com/BLAKE3-team/BLAKE3-specs/raw/master/blake3.pdf)  | A | |
 | AES-CMAC      | [RFC 4493](https://datatracker.ietf.org/doc/html/rfc4493) & [NIST SP 800-38B](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-38b.pdf) | A | |
 | AES-GMAC      | [NIST SP 800-38D](https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf)            | A | |
 | Poly1305-AES  | [The Poly1305-AES message-authentication code](https://cr.yp.to/mac/poly1305-20050329.pdf)                  | A | |
@@ -299,4 +302,4 @@ Diffie-Hellman 鍵交換の実装には以下のグループが承認されて�
 
 PQC 実装は、堅牢化されたコードや実装リファレンスはまだ最低限しか存在しないため、[FIPS-203](https://csrc.nist.gov/pubs/fips/203/ipd)/[204](https://csrc.nist.gov/pubs/fips/204/ipd)/[205](https://csrc.nist.gov/pubs/fips/205/ipd) に準拠していなければなりません。 https://www.nist.gov/news-events/news/2024/08/nist-releases-first-3-finalized-post-quantum-encryption-standards
 
-提案されているハイブリッド TLS 鍵交換グループは、[draft-tls-westerbaan-xyber768x00-03](https://www.ietf.org/archive/id/draft-tls-westerbaan-xyber768d00-03.txt) で規定され、[Firefox リリース 132](https://www.ietf.org/archive/id/draft-tls-westerbaan-xyber768d00-03.txt) や [Chrome リリース 131](https://security.googleblog.com/2024/09/a-new-path-for-kyber-on-web.html) などの主要なブラウザでサポートされており、暗号テスト環境や業界や政府が承認したライブラリ内で利用可能な場合に使用できます (MAY)。
+提案されている [mlkem768x25519](https://datatracker.ietf.org/doc/draft-kwiatkowski-tls-ecdhe-mlkem/03/) ポスト量子ハイブリッド TLS 鍵交換方式は、[Firefox リリース 132](https://www.mozilla.org/en-US/firefox/132.0/releasenotes/) や [Chrome リリース 131](https://security.googleblog.com/2024/09/a-new-path-for-kyber-on-web.html) などの主要なブラウザでサポートされています。暗号テスト環境や、業界や政府が承認したライブラリ内で利用可能な場合に使用できます (MAY)。


### PR DESCRIPTION
0x97-Appendix-V_Cryptography.md 2025/5/25 更新情報
https://github.com/OWASP/ASVS/commit/187bc1f7bc1b21d440fd282ff51c2b0521551794#diff-2e9f6d11881cae6343ed9c74c9f54dc472c907a126b90a8581b5a4be8e0ad3af https://github.com/OWASP/ASVS/commit/80723c55c70f21e7fa5f8380921d4adb30d72a16#diff-2e9f6d11881cae6343ed9c74c9f54dc472c907a126b90a8581b5a4be8e0ad3af https://github.com/OWASP/ASVS/commit/88cf126fa10abec154d833e5fd33ff2995807d2b#diff-2e9f6d11881cae6343ed9c74c9f54dc472c907a126b90a8581b5a4be8e0ad3af