### PR TITLE
fix #2465 0x94-Appendix-E_Contributors.md 2025/9/11 更新分の取り込み

### DIFF
--- a/5.0/ja/0x94-Appendix-E_Contributors.md
+++ b/5.0/ja/0x94-Appendix-E_Contributors.md
@@ -68,4 +68,4 @@ ASVS 4.0.0 のリリース以降にコメントやプルリクエストをオー
 | Lyz ([lyz-code](https://github.com/lyz-code)) | Martin Riedel ([mrtnrdl](https://github.com/mrtnrdl)) | KIM Jaesuck ([tcaesvk](https://github.com/tcaesvk)) | Barbara Schachner ([bschach](https://github.com/bschach))  |
 | René Reuter ([AresSec](https://github.com/AresSec)) | [carhackpils](https://github.com/carhackpils) | Tyler ([tyler2cr](https://github.com/tyler2cr)) | Hugo ([hasousa](https://github.com/hasousa))  |
 | Wouter Bloeyaert ([Someniak](https://github.com/Someniak)) | Mark de Rijk ([markderijkinfosec](https://github.com/markderijkinfosec)) | Ramin ([picohub](https://github.com/picohub)) | Philip D. Turner ([philipdturner](https://github.com/philipdturner))  |
-| Will Chatham ([willc](https://github.com/willc))  |
+| Will Chatham ([willc](https://github.com/willc)) | | | |


### PR DESCRIPTION
0x94-Appendix-E_Contributors.md 2025/9/11 更新情報
https://github.com/OWASP/ASVS/commit/60c3d0282bbe1b7f590102b93112e1396df13df3#diff-59429d8ee5b437bf98cd32fbb3b037fbc4f6dbeb591d7161a6d82bb0a4feeb5f https://github.com/OWASP/ASVS/commit/d3af34547e63a59620d473bdaeaf69e66fc88de0#diff-59429d8ee5b437bf98cd32fbb3b037fbc4f6dbeb591d7161a6d82bb0a4feeb5f